### PR TITLE
Check for existing gist before trying to render

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,9 @@ class Gist extends Component {
   }
 
   componentDidMount() {
+    if (!this.gist) {
+      return;
+    }
     const self = this;
     const allFiles = Object.values(this.gist.files);
     allFiles.forEach((file, key) => {
@@ -34,6 +37,13 @@ class Gist extends Component {
   }
 
   render() {
+    if (!this.gist) {
+      return (
+        <div className="alert alert-danger">
+          This gist is not available anymore. <Link to="/">Go home</Link>.
+        </div>
+      );
+    }
     return(
         <div className="gistResultContainer">
           <h1>{this.gist.id}</h1>


### PR DESCRIPTION
Hi Vinit, this is my understanding what is happening:

- When loading or refreshing the page, a list of gists is loaded
- When the route is `/`, it will not show any gist;
- When you click on a gist link, the route will become `/<gistid>`, and it will find the corresponding gist in the list and display it
- When you reload the page, the route is still `/<gistid>`, it will load a new list of gists, and try to find the gist with the given `gistid` in the list. But since it is an updated list, the gist may not be in the list anymore, so the `Gist` component is rendered without a valid `gist`. 
